### PR TITLE
Juan santiago

### DIFF
--- a/lib/controller/ServerController.dart
+++ b/lib/controller/ServerController.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:pro_tocol/model/entities/DataBaseEntities.dart';
 import 'package:pro_tocol/model/entities/Server.dart';
 import 'package:pro_tocol/model/repositories/ServerRepository.dart';
@@ -75,19 +76,47 @@ class ServerController {
 
   Future<void> _detectLinuxDistro(Server server) async {
     try {
+      if (!server.sshService.isConnected) {
+        _setDefaultDistroValues(server, 'Not connected');
+        return;
+      }
+
       final rawOsRelease = await server.sshService.runSingleCommand('cat /etc/os-release');
+      
+      if (rawOsRelease.trim().isEmpty) {
+        _setDefaultDistroValues(server, 'Empty os-release');
+        return;
+      }
+
       final values = _parseOsRelease(rawOsRelease);
+      
+      if (values.isEmpty) {
+        _setDefaultDistroValues(server, 'Failed to parse os-release');
+        return;
+      }
+
       final id = values['ID']?.toLowerCase();
       final name = values['NAME']?.replaceAll('"', '').trim();
       final idLike = values['ID_LIKE']?.toLowerCase();
 
+      if (id == null || id.isEmpty) {
+        _setDefaultDistroValues(server, 'Missing ID field');
+        return;
+      }
+
       server.distroName = name ?? id ?? 'Linux';
       server.packageManager = _resolvePackageManager(id, idLike);
-    } catch (_) {
-      // No interrumpimos la conexión si la detección falla.
-      server.distroName ??= 'Linux';
-      server.packageManager ??= 'unknown';
+      debugPrint('[ServerController] Distro detected: ${server.distroName} (PM: ${server.packageManager})');
+    } catch (e) {
+      debugPrint('[ServerController] Distro detection failed: $e');
+      _setDefaultDistroValues(server, e.toString());
     }
+  }
+
+  void _setDefaultDistroValues(Server server, String reason) {
+    server.distroName = 'Linux';
+    server.packageManager = 'unknown';
+    debugPrint('[ServerController] Using defaults ($reason)');
   }
 
   Map<String, String> _parseOsRelease(String raw) {

--- a/lib/controller/ServerController.dart
+++ b/lib/controller/ServerController.dart
@@ -65,9 +65,59 @@ class ServerController {
 
       // Si fue exitoso, lo guardamos en las conexiones activas
       _activeConnections[serverId] = server;
+
+      // Detectar información de distro y package manager en segundo plano.
+      await _detectLinuxDistro(server);
     } catch (e) {
       throw Exception('Fallo al conectar con ${config.host}: $e');
     }
+  }
+
+  Future<void> _detectLinuxDistro(Server server) async {
+    try {
+      final rawOsRelease = await server.sshService.runSingleCommand('cat /etc/os-release');
+      final values = _parseOsRelease(rawOsRelease);
+      final id = values['ID']?.toLowerCase();
+      final name = values['NAME']?.replaceAll('"', '').trim();
+      final idLike = values['ID_LIKE']?.toLowerCase();
+
+      server.distroName = name ?? id ?? 'Linux';
+      server.packageManager = _resolvePackageManager(id, idLike);
+    } catch (_) {
+      // No interrumpimos la conexión si la detección falla.
+      server.distroName ??= 'Linux';
+      server.packageManager ??= 'unknown';
+    }
+  }
+
+  Map<String, String> _parseOsRelease(String raw) {
+    final lines = raw.split('\n');
+    final Map<String, String> values = {};
+
+    for (final line in lines) {
+      if (line.trim().isEmpty || !line.contains('=')) continue;
+      final index = line.indexOf('=');
+      final key = line.substring(0, index).trim();
+      final value = line.substring(index + 1).trim().replaceAll('"', '');
+      values[key] = value;
+    }
+
+    return values;
+  }
+
+  String _resolvePackageManager(String? id, String? idLike) {
+    final normalizedIdLike = idLike ?? '';
+
+    if (id == 'ubuntu' || id == 'debian' || normalizedIdLike.contains('debian')) {
+      return 'apt';
+    }
+    if (id == 'arch' || id == 'manjaro' || normalizedIdLike.contains('arch')) {
+      return 'pacman';
+    }
+    if (id == 'fedora' || id == 'rhel' || normalizedIdLike.contains('fedora') || normalizedIdLike.contains('rhel')) {
+      return 'dnf';
+    }
+    return 'unknown';
   }
 
   Future<void> disconnectFromServer(int serverId) async {

--- a/lib/controller/TempSessionController.dart
+++ b/lib/controller/TempSessionController.dart
@@ -1,4 +1,6 @@
 
+import 'package:flutter/foundation.dart';
+
 import 'package:pro_tocol/model/entities/TempSession.dart';
 import 'package:pro_tocol/model/entities/TempSessionConfig.dart';
 import 'package:pro_tocol/model/repositories/TempSessionRepository.dart';
@@ -53,18 +55,47 @@ class TempSessionController {
 
   Future<void> _detectLinuxDistro(TempSession session) async {
     try {
+      if (!session.sshService.isConnected) {
+        _setDefaultDistroValues(session, 'Not connected');
+        return;
+      }
+
       final rawOsRelease = await session.sshService.runSingleCommand('cat /etc/os-release');
+      
+      if (rawOsRelease.trim().isEmpty) {
+        _setDefaultDistroValues(session, 'Empty os-release');
+        return;
+      }
+
       final values = _parseOsRelease(rawOsRelease);
+      
+      if (values.isEmpty) {
+        _setDefaultDistroValues(session, 'Failed to parse os-release');
+        return;
+      }
+
       final id = values['ID']?.toLowerCase();
       final name = values['NAME']?.replaceAll('"', '').trim();
       final idLike = values['ID_LIKE']?.toLowerCase();
 
+      if (id == null || id.isEmpty) {
+        _setDefaultDistroValues(session, 'Missing ID field');
+        return;
+      }
+
       session.distroName = name ?? id ?? 'Linux';
       session.packageManager = _resolvePackageManager(id, idLike);
-    } catch (_) {
-      session.distroName ??= 'Linux';
-      session.packageManager ??= 'unknown';
+      debugPrint('[TempSessionController] Distro detected: ${session.distroName} (PM: ${session.packageManager})');
+    } catch (e) {
+      debugPrint('[TempSessionController] Distro detection failed: $e');
+      _setDefaultDistroValues(session, e.toString());
     }
+  }
+
+  void _setDefaultDistroValues(TempSession session, String reason) {
+    session.distroName = 'Linux';
+    session.packageManager = 'unknown';
+    debugPrint('[TempSessionController] Using defaults ($reason)');
   }
 
   Map<String, String> _parseOsRelease(String raw) {

--- a/lib/controller/TempSessionController.dart
+++ b/lib/controller/TempSessionController.dart
@@ -43,10 +43,58 @@ class TempSessionController {
       // Usamos el host como llave temporal o un hash de la config
       _activeSessions[host] = session;
 
+      await _detectLinuxDistro(session);
+
       return session;
     } catch (e) {
       throw Exception('Fallo al conectar sesión temporal con $host: $e');
     }
+  }
+
+  Future<void> _detectLinuxDistro(TempSession session) async {
+    try {
+      final rawOsRelease = await session.sshService.runSingleCommand('cat /etc/os-release');
+      final values = _parseOsRelease(rawOsRelease);
+      final id = values['ID']?.toLowerCase();
+      final name = values['NAME']?.replaceAll('"', '').trim();
+      final idLike = values['ID_LIKE']?.toLowerCase();
+
+      session.distroName = name ?? id ?? 'Linux';
+      session.packageManager = _resolvePackageManager(id, idLike);
+    } catch (_) {
+      session.distroName ??= 'Linux';
+      session.packageManager ??= 'unknown';
+    }
+  }
+
+  Map<String, String> _parseOsRelease(String raw) {
+    final lines = raw.split('\n');
+    final Map<String, String> values = {};
+
+    for (final line in lines) {
+      if (line.trim().isEmpty || !line.contains('=')) continue;
+      final index = line.indexOf('=');
+      final key = line.substring(0, index).trim();
+      final value = line.substring(index + 1).trim().replaceAll('"', '');
+      values[key] = value;
+    }
+
+    return values;
+  }
+
+  String _resolvePackageManager(String? id, String? idLike) {
+    final normalizedIdLike = idLike ?? '';
+
+    if (id == 'ubuntu' || id == 'debian' || normalizedIdLike.contains('debian')) {
+      return 'apt';
+    }
+    if (id == 'arch' || id == 'manjaro' || normalizedIdLike.contains('arch')) {
+      return 'pacman';
+    }
+    if (id == 'fedora' || id == 'rhel' || normalizedIdLike.contains('fedora') || normalizedIdLike.contains('rhel')) {
+      return 'dnf';
+    }
+    return 'unknown';
   }
 
   /// 2. GESTIÓN DE ESTADO

--- a/lib/model/entities/Server.dart
+++ b/lib/model/entities/Server.dart
@@ -8,6 +8,9 @@ class Server {
   final ServerConfig config;
   final SSHService sshService = SSHService();
 
+  String? distroName;
+  String? packageManager;
+
   Server({required this.config});
 
 }

--- a/lib/model/entities/TempSession.dart
+++ b/lib/model/entities/TempSession.dart
@@ -7,6 +7,9 @@ class TempSession {
   final TempSessionConfig config;
   final SSHService sshService = SSHService();
 
+  String? distroName;
+  String? packageManager;
+
   TempSession({required this.config});
 
 }

--- a/lib/view/pages/DistroLogsPage.dart
+++ b/lib/view/pages/DistroLogsPage.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pro_tocol/logic/command_history_manager.dart';
+import 'package:pro_tocol/model/entities/Server.dart';
+import 'package:pro_tocol/model/entities/TempSession.dart';
 import 'package:pro_tocol/view/theme/AppColors.dart';
 
 class DistroLogsPage extends StatefulWidget {
   final CommandHistoryManager commandHistoryManager;
+  final Server? activeServer;
+  final TempSession? activeSession;
 
-  const DistroLogsPage({super.key, required this.commandHistoryManager});
+  const DistroLogsPage({
+    super.key,
+    required this.commandHistoryManager,
+    this.activeServer,
+    this.activeSession,
+  });
 
   @override
   State<DistroLogsPage> createState() => _DistroLogsPageState();
@@ -16,6 +25,9 @@ class _DistroLogsPageState extends State<DistroLogsPage> {
   @override
   Widget build(BuildContext context) {
     final history = widget.commandHistoryManager.getHistory();
+    final distroName = widget.activeServer?.distroName ?? widget.activeSession?.distroName ?? 'Linux';
+    final packageManager = widget.activeServer?.packageManager ?? widget.activeSession?.packageManager ?? 'unknown';
+    final distroIcon = _getDistroIcon(distroName);
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -49,35 +61,97 @@ class _DistroLogsPageState extends State<DistroLogsPage> {
             colors: [AppColors.background, AppColors.surface.withOpacity(0.1)],
           ),
         ),
-        child: history.isEmpty
-            ? const Center(
-                child: Text(
-                  'No hay comandos en el historial',
-                  style: TextStyle(color: AppColors.textMuted),
-                ),
-              )
-            : ListView.builder(
-                itemCount: history.length,
-                itemBuilder: (context, index) {
-                  final command = history[history.length - 1 - index]; // Más reciente primero
-                  return ListTile(
-                    title: Text(
-                      command,
-                      style: const TextStyle(color: AppColors.textPrimary),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Text(distroIcon, style: const TextStyle(fontSize: 28)),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              distroName,
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Package Manager: $packageManager',
+                              style: const TextStyle(color: AppColors.textSecondary),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  const Divider(color: AppColors.border),
+                  const SizedBox(height: 12),
+                  const Text(
+                    'Command History',
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
                     ),
-                    trailing: const Icon(Icons.copy, color: AppColors.primary),
-                    onTap: () async {
-                      await Clipboard.setData(ClipboardData(text: command));
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Comando copiado: $command')),
-                        );
-                      }
-                    },
-                  );
-                },
+                  ),
+                ],
               ),
+            ),
+            Expanded(
+              child: history.isEmpty
+                  ? const Center(
+                      child: Text(
+                        'No hay comandos en el historial',
+                        style: TextStyle(color: AppColors.textMuted),
+                      ),
+                    )
+                  : ListView.builder(
+                      itemCount: history.length,
+                      itemBuilder: (context, index) {
+                        final command = history[history.length - 1 - index]; // Más reciente primero
+                        return ListTile(
+                          title: Text(
+                            command,
+                            style: const TextStyle(color: AppColors.textPrimary),
+                          ),
+                          trailing: const Icon(Icons.copy, color: AppColors.primary),
+                          onTap: () async {
+                            await Clipboard.setData(ClipboardData(text: command));
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Comando copiado: $command')),
+                              );
+                            }
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  String _getDistroIcon(String distroName) {
+    final normalized = distroName.toLowerCase();
+    if (normalized.contains('ubuntu')) return '🐧';
+    if (normalized.contains('debian')) return '🦆';
+    if (normalized.contains('arch')) return '🌀';
+    if (normalized.contains('manjaro')) return '🌲';
+    if (normalized.contains('fedora')) return '🛡️';
+    if (normalized.contains('rhel') || normalized.contains('red hat')) return '🔥';
+    return '🐧';
   }
 }

--- a/lib/view/pages/ServerPage.dart
+++ b/lib/view/pages/ServerPage.dart
@@ -258,6 +258,9 @@ void _handleTerminalInput(String input, SSHSession session) {
   @override
   Widget build(BuildContext context) {
     final connectionString = "${widget.serverConfig.username}@${widget.serverConfig.host}";
+    final distroName = _activeServer?.distroName ?? 'Linux';
+    final packageManager = _activeServer?.packageManager ?? 'unknown';
+    final distroIcon = _getDistroIcon(distroName);
 
     return DefaultTabController(
       length: 3,
@@ -272,6 +275,28 @@ void _handleTerminalInput(String input, SSHSession session) {
                   style: const TextStyle(color: AppColors.textPrimary, fontSize: 18, fontWeight: FontWeight.bold)
               ),
               Text(connectionString, style: const TextStyle(color: AppColors.textMuted, fontSize: 12)),
+              if (!widget.isTemporarySession) ...[
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(distroIcon, style: const TextStyle(fontSize: 18)),
+                    const SizedBox(width: 8),
+                    Column(
+                      children: [
+                        Text(
+                          distroName,
+                          style: const TextStyle(color: AppColors.textPrimary, fontSize: 14),
+                        ),
+                        Text(
+                          'Package Manager: $packageManager',
+                          style: const TextStyle(color: AppColors.textMuted, fontSize: 10),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
             ],
           ),
           centerTitle: true,
@@ -502,6 +527,17 @@ void _handleTerminalInput(String input, SSHSession session) {
         ],
       ),
     );
+  }
+
+  String _getDistroIcon(String distroName) {
+    final normalized = distroName.toLowerCase();
+    if (normalized.contains('ubuntu')) return '🐧';
+    if (normalized.contains('debian')) return '🦆';
+    if (normalized.contains('arch')) return '🌀';
+    if (normalized.contains('manjaro')) return '🌲';
+    if (normalized.contains('fedora')) return '🛡️';
+    if (normalized.contains('rhel') || normalized.contains('red hat')) return '🔥';
+    return '🐧';
   }
 
   String _formatSize(int bytes) {

--- a/lib/view/pages/WorkspacePage.dart
+++ b/lib/view/pages/WorkspacePage.dart
@@ -227,6 +227,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
       case ViewType.distroLogs:
         return DistroLogsPage(
           commandHistoryManager: widget.serverController.commandHistoryManager,
+          activeServer: _selectedServer != null ? widget.serverController.getActiveServer(_selectedServer!.id) : null,
+          activeSession: _selectedTempSession != null ? widget.tempSessionController.getValidSession(_selectedTempSession!.host) : null,
         );
       case ViewType.home:
       default:


### PR DESCRIPTION
# Pull Request: Detección automática de distro Linux + integración en Distro & Logs

## Objetivo
Detectar automáticamente la distribución Linux al conectarse por SSH y mostrar la información en la nueva pestaña **Distro & Logs**.

## Cambios realizados

### Backend (Controllers)
- `ServerController` y `TempSessionController`:
  - Ejecutan `cat /etc/os-release` tras conexión SSH.
  - Parsean `ID`, `NAME`, `ID_LIKE`.
  - Mapean a package manager: `apt` (Ubuntu/Debian), `pacman` (Arch/Manjaro), `dnf` (Fedora/RHEL).
  - Fallback seguro: `Linux` / `unknown`.

### Modelos (Entities)
- `Server` y `TempSession`:
  - Nuevos campos: `distroName?`, `packageManager?`.

### Interfaz de usuario
- **Nueva página `DistroLogsPage`**:
  - Cabecera con distro (emoji + nombre + package manager).
  - Historial de últimos 50 comandos (con copiar al portapapeles).
  - Botón para limpiar historial.
- **`WorkspacePage`**:
  - Nueva pestaña "Distro & Logs" (icono `Icons.history`).
- **`ServerPage`**:
  - Muestra distro y package manager en el AppBar.

### Funcionalidad existente preservada
- Navegación con flechas (↑/↓) en terminal.
- Guardado de historial (50 comandos).
- Comportamiento original sin cambios.

## Criterios de aceptación (todos cumplidos)
✅ Detección automática de distro Linux al conectar.  
✅ Parseo de `/etc/os-release`.  
✅ Identificación de package manager.  
✅ Logo de distro en header del servidor.  
✅ Integración en pestaña Distro & Logs.  
✅ Funcionalidad existente intacta.  

## Pruebas
- `flutter analyze` sin errores.
- Prueba manual en Ubuntu, Debian, Arch, Fedora.
- Manejo de errores (sin `/etc/os-release`, malformado, etc.).
- Copiar comandos, limpiar historial, flechas funcionando.

## Conclusión
Feature completa, no rompe nada existente, lista para merge. ✅