### PR TITLE
Juan santiago

### DIFF
--- a/lib/controller/TempSessionController.dart
+++ b/lib/controller/TempSessionController.dart
@@ -1,18 +1,10 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
-
-import 'package:pro_tocol/logic/apps_manager_catalog.dart';
-import 'package:pro_tocol/logic/apps_manager_state.dart';
 import 'package:pro_tocol/model/entities/TempSession.dart';
 import 'package:pro_tocol/model/entities/TempSessionConfig.dart';
 import 'package:pro_tocol/model/repositories/TempSessionRepository.dart';
 import 'package:pro_tocol/logic/command_history_manager.dart';
-import 'package:pro_tocol/logic/package_install_command_builder.dart';
-import 'package:pro_tocol/logic/template_model.dart';
-import 'package:pro_tocol/logic/template_run_result.dart';
-import 'package:pro_tocol/logic/template_step.dart';
 
 class TempSessionController {
   final TempSessionRepository _repository;

--- a/lib/injection.dart
+++ b/lib/injection.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:isar/isar.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:xterm/xterm.dart';
 
 // --- DAOs ---
 import 'package:pro_tocol/model/daos/AiConfigDAO.dart';
@@ -52,6 +53,9 @@ Future<void> setupDependencies(Isar isar) async {
 
   // 3. Managers
   getIt.registerLazySingleton<CommandHistoryManager>(() => CommandHistoryManager());
+
+  // 3.1 Terminal (singleton compartido con el Tab activo)
+  getIt.registerLazySingleton<Terminal>(() => Terminal(maxLines: 10000));
 
   // 4. Controladores Globales
   getIt.registerLazySingleton<SshKeyController>(() => SshKeyController());

--- a/lib/model/entities/DataBaseEntities.g.dart
+++ b/lib/model/entities/DataBaseEntities.g.dart
@@ -1640,3 +1640,876 @@ extension ServerConfigQueryProperty
     });
   }
 }
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetAiConfigCollection on Isar {
+  IsarCollection<AiConfig> get aiConfigs => this.collection();
+}
+
+const AiConfigSchema = CollectionSchema(
+  name: r'AiConfig',
+  id: -4202509664049949584,
+  properties: {
+    r'host': PropertySchema(
+      id: 0,
+      name: r'host',
+      type: IsarType.string,
+    ),
+    r'model': PropertySchema(
+      id: 1,
+      name: r'model',
+      type: IsarType.string,
+    ),
+    r'port': PropertySchema(
+      id: 2,
+      name: r'port',
+      type: IsarType.long,
+    ),
+    r'provider': PropertySchema(
+      id: 3,
+      name: r'provider',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _aiConfigEstimateSize,
+  serialize: _aiConfigSerialize,
+  deserialize: _aiConfigDeserialize,
+  deserializeProp: _aiConfigDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _aiConfigGetId,
+  getLinks: _aiConfigGetLinks,
+  attach: _aiConfigAttach,
+  version: '3.1.0+1',
+);
+
+int _aiConfigEstimateSize(
+  AiConfig object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.host.length * 3;
+  bytesCount += 3 + object.model.length * 3;
+  bytesCount += 3 + object.provider.length * 3;
+  return bytesCount;
+}
+
+void _aiConfigSerialize(
+  AiConfig object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.host);
+  writer.writeString(offsets[1], object.model);
+  writer.writeLong(offsets[2], object.port);
+  writer.writeString(offsets[3], object.provider);
+}
+
+AiConfig _aiConfigDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = AiConfig(
+    host: reader.readStringOrNull(offsets[0]) ?? '127.0.0.1',
+    model: reader.readStringOrNull(offsets[1]) ?? '',
+    port: reader.readLongOrNull(offsets[2]) ?? 11434,
+    provider: reader.readStringOrNull(offsets[3]) ?? 'ollama',
+  );
+  object.id = id;
+  return object;
+}
+
+P _aiConfigDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset) ?? '127.0.0.1') as P;
+    case 1:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 2:
+      return (reader.readLongOrNull(offset) ?? 11434) as P;
+    case 3:
+      return (reader.readStringOrNull(offset) ?? 'ollama') as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _aiConfigGetId(AiConfig object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _aiConfigGetLinks(AiConfig object) {
+  return [];
+}
+
+void _aiConfigAttach(IsarCollection<dynamic> col, Id id, AiConfig object) {
+  object.id = id;
+}
+
+extension AiConfigQueryWhereSort on QueryBuilder<AiConfig, AiConfig, QWhere> {
+  QueryBuilder<AiConfig, AiConfig, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension AiConfigQueryWhere on QueryBuilder<AiConfig, AiConfig, QWhereClause> {
+  QueryBuilder<AiConfig, AiConfig, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension AiConfigQueryFilter
+    on QueryBuilder<AiConfig, AiConfig, QFilterCondition> {
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'host',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'host',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'host',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'host',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> hostIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'host',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'model',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'model',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'model',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> modelIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'model',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> portEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'port',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> portGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'port',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> portLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'port',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> portBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'port',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'provider',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'provider',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'provider',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterFilterCondition> providerIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'provider',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension AiConfigQueryObject
+    on QueryBuilder<AiConfig, AiConfig, QFilterCondition> {}
+
+extension AiConfigQueryLinks
+    on QueryBuilder<AiConfig, AiConfig, QFilterCondition> {}
+
+extension AiConfigQuerySortBy on QueryBuilder<AiConfig, AiConfig, QSortBy> {
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByHost() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'host', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByHostDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'host', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByPort() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'port', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByPortDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'port', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByProvider() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'provider', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> sortByProviderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'provider', Sort.desc);
+    });
+  }
+}
+
+extension AiConfigQuerySortThenBy
+    on QueryBuilder<AiConfig, AiConfig, QSortThenBy> {
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByHost() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'host', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByHostDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'host', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByPort() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'port', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByPortDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'port', Sort.desc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByProvider() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'provider', Sort.asc);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QAfterSortBy> thenByProviderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'provider', Sort.desc);
+    });
+  }
+}
+
+extension AiConfigQueryWhereDistinct
+    on QueryBuilder<AiConfig, AiConfig, QDistinct> {
+  QueryBuilder<AiConfig, AiConfig, QDistinct> distinctByHost(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'host', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QDistinct> distinctByModel(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'model', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QDistinct> distinctByPort() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'port');
+    });
+  }
+
+  QueryBuilder<AiConfig, AiConfig, QDistinct> distinctByProvider(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'provider', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension AiConfigQueryProperty
+    on QueryBuilder<AiConfig, AiConfig, QQueryProperty> {
+  QueryBuilder<AiConfig, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<AiConfig, String, QQueryOperations> hostProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'host');
+    });
+  }
+
+  QueryBuilder<AiConfig, String, QQueryOperations> modelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'model');
+    });
+  }
+
+  QueryBuilder<AiConfig, int, QQueryOperations> portProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'port');
+    });
+  }
+
+  QueryBuilder<AiConfig, String, QQueryOperations> providerProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'provider');
+    });
+  }
+}

--- a/lib/model/repositories/AiConfigRepository.dart
+++ b/lib/model/repositories/AiConfigRepository.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:isar/isar.dart';
 import 'package:pro_tocol/model/daos/AiConfigDAO.dart';
 import 'package:pro_tocol/model/entities/DataBaseEntities.dart';
 

--- a/lib/view/components/chat_bubble.dart
+++ b/lib/view/components/chat_bubble.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import '../../model/entities/chat_message.dart'; 
+import 'package:pro_tocol/view/theme/AppColors.dart';
+import '../../model/entities/chat_message.dart';
 
 class ChatBubble extends StatelessWidget {
   final ChatMessage message;
+  final void Function(String command)? onExecuteCommand;
 
-  const ChatBubble({super.key, required this.message});
+  const ChatBubble({super.key, required this.message, this.onExecuteCommand});
+
+  static final RegExp _codeBlockRegex = RegExp(r'```[\w]*\n([\s\S]*?)\n```');
 
   void _copyToClipboard(BuildContext context) {
     Clipboard.setData(ClipboardData(text: message.text));
@@ -20,6 +24,19 @@ class ChatBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final styleSheet = MarkdownStyleSheet(
+      p: const TextStyle(color: Colors.white, fontSize: 15),
+      code: TextStyle(
+        backgroundColor: Colors.black,
+        color: Colors.greenAccent[400],
+        fontFamily: 'monospace',
+      ),
+      codeblockDecoration: BoxDecoration(
+        color: Colors.black,
+        borderRadius: BorderRadius.circular(8),
+      ),
+    );
+
     return Align(
       alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
@@ -46,21 +63,7 @@ class ChatBubble extends StatelessWidget {
                 style: const TextStyle(color: Colors.white, fontSize: 16),
               )
             else
-              MarkdownBody(
-                data: message.text,
-                styleSheet: MarkdownStyleSheet(
-                  p: const TextStyle(color: Colors.white, fontSize: 15),
-                  code: TextStyle(
-                    backgroundColor: Colors.black,
-                    color: Colors.greenAccent[400],
-                    fontFamily: 'monospace',
-                  ),
-                  codeblockDecoration: BoxDecoration(
-                    color: Colors.black,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              ),
+              ..._buildAiContent(styleSheet),
             
             if (!message.isUser) ...[
               const SizedBox(height: 10),
@@ -75,6 +78,61 @@ class ChatBubble extends StatelessWidget {
             ]
           ],
         ),
+      ),
+    );
+  }
+
+  List<Widget> _buildAiContent(MarkdownStyleSheet styleSheet) {
+    final matches = _codeBlockRegex.allMatches(message.text).toList();
+    if (matches.isEmpty) {
+      return [MarkdownBody(data: message.text, styleSheet: styleSheet)];
+    }
+
+    final widgets = <Widget>[];
+    var lastIndex = 0;
+
+    for (final match in matches) {
+      final before = message.text.substring(lastIndex, match.start);
+      if (before.trim().isNotEmpty) {
+        widgets.add(MarkdownBody(data: before, styleSheet: styleSheet));
+      }
+
+      final fencedBlock = message.text.substring(match.start, match.end);
+      widgets.add(MarkdownBody(data: fencedBlock, styleSheet: styleSheet));
+
+      final codeContent = match.group(1)?.trim() ?? '';
+      if (codeContent.isNotEmpty && onExecuteCommand != null) {
+        widgets.add(const SizedBox(height: 6));
+        widgets.add(_buildExecuteButton(codeContent));
+      }
+
+      lastIndex = match.end;
+    }
+
+    final after = message.text.substring(lastIndex);
+    if (after.trim().isNotEmpty) {
+      widgets.add(MarkdownBody(data: after, styleSheet: styleSheet));
+    }
+
+    return widgets;
+  }
+
+  Widget _buildExecuteButton(String command) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton.icon(
+        icon: const Icon(Icons.terminal, size: 18, color: AppColors.primary),
+        label: const Text('Ejecutar en Terminal'),
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.textPrimary,
+          backgroundColor: AppColors.surfaceHighlight,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: const BorderSide(color: AppColors.primary),
+          ),
+        ),
+        onPressed: () => onExecuteCommand?.call(command),
       ),
     );
   }

--- a/lib/view/pages/ServerPage.dart
+++ b/lib/view/pages/ServerPage.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/material.dart';
-import 'package:pro_tocol/controller/ServerCommandController.dart';
 import 'package:pro_tocol/controller/ServerConnectionController.dart';
 import 'package:pro_tocol/injection.dart';
 import 'package:pro_tocol/view/pages/server_tabs/AppsManagerTab.dart';
@@ -28,51 +27,9 @@ class ServerPage extends StatefulWidget {
     required this.serverConfig,
     this.isTemporarySession = false,
   });
-  void _showChatModal(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true, 
-      backgroundColor: Colors.transparent,
-      builder: (context) {
-        return Padding(
-          padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: Container(
-            height: MediaQuery.of(context).size.height * 0.7, // Altura del 70% de la pantalla
-            decoration: const BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.vertical(top: Radius.circular(25)),
-            ),
-            child: Column(
-              children: [
-                Container(
-                  margin: const EdgeInsets.symmetric(vertical: 12),
-                  height: 5,
-                  width: 40,
-                  decoration: BoxDecoration(
-                    color: Colors.grey[600],
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                ),
-                const Text(
-                  "Asistente Pro-Tocol IA",
-                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
-                ),
-                const SizedBox(height: 8),
-                const Divider(color: Colors.white10, height: 1),
-                const Expanded(
-                  child: ChatIaTab(), //cargamos interfaz de burbujas
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
   @override
   State<ServerPage> createState() => _ServerPageState();
   ServerConnectionController get _connectionController => getIt<ServerConnectionController>();
-  ServerCommandController get _commandController => getIt<ServerCommandController>();
 }
 
 class _ServerPageState extends State<ServerPage> {
@@ -140,7 +97,7 @@ class _ServerPageState extends State<ServerPage> {
   @override
   void initState() {
     super.initState();
-    terminal = Terminal(maxLines: 10000);
+    terminal = getIt<Terminal>();
     _connectToServerController();
   }
 

--- a/lib/view/pages/TempSessionPage.dart
+++ b/lib/view/pages/TempSessionPage.dart
@@ -35,7 +35,7 @@ class _TempSessionPageState extends State<TempSessionPage> {
   @override
   void initState() {
     super.initState();
-    terminal = Terminal(maxLines: 10000);
+    terminal = getIt<Terminal>();
     _connectToTerminal();
   }
 

--- a/lib/view/pages/server_tabs/ChatIaTab.dart
+++ b/lib/view/pages/server_tabs/ChatIaTab.dart
@@ -5,6 +5,7 @@ import 'package:pro_tocol/model/entities/chat_message.dart';
 import 'package:pro_tocol/model/services/ia_service.dart';
 import 'package:pro_tocol/view/components/chat_bubble.dart';
 import 'package:pro_tocol/view/theme/AppColors.dart';
+import 'package:xterm/xterm.dart';
 
 class ChatIaTab extends StatefulWidget {
   const ChatIaTab({super.key});
@@ -78,6 +79,56 @@ class _ChatIaTabState extends State<ChatIaTab> {
     }
   }
 
+  Future<void> _executeInTerminal(String command) async {
+    final trimmed = command.trim();
+    if (trimmed.isEmpty) return;
+
+    final isMultiLine = trimmed.contains('\n') || trimmed.contains('\r');
+    if (isMultiLine) {
+      final shouldRun = await _confirmMultiLineCommand(trimmed);
+      if (!shouldRun) return;
+    }
+
+    final terminal = getIt<Terminal>();
+    terminal.textInput(trimmed);
+    terminal.keyInput(TerminalKey.enter);
+    _scrollToBottom();
+  }
+
+  Future<bool> _confirmMultiLineCommand(String command) async {
+    if (!mounted) return false;
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: AppColors.surface,
+          title: const Text(
+            'Ejecutar comando de varias lineas',
+            style: TextStyle(color: AppColors.textPrimary),
+          ),
+          content: Text(
+            'Este comando tiene varias lineas. Quieres ejecutarlo en la terminal activa?',
+            style: const TextStyle(color: AppColors.textSecondary),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              style: TextButton.styleFrom(foregroundColor: AppColors.primary),
+              child: const Text('Ejecutar'),
+            ),
+          ],
+        );
+      },
+    );
+
+    return result ?? false;
+  }
+
   void _scrollToBottom() {
     Future.delayed(const Duration(milliseconds: 100), () {
       if (_scrollController.hasClients) {
@@ -139,7 +190,10 @@ class _ChatIaTabState extends State<ChatIaTab> {
               if (!message.isUser && message.text.isEmpty && _awaitingFirstChunk) {
                 return const _TypingIndicatorBubble();
               }
-              return ChatBubble(message: message);
+              return ChatBubble(
+                message: message,
+                onExecuteCommand: message.isUser ? null : _executeInTerminal,
+              );
             },
           ),
         ),


### PR DESCRIPTION
<h1 class="font-editorial font-bold first:mt-xs mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg leading-[1.5em] lg:text-xl" id="pr-es-46--bridge-ia-terminal">R: ES-46 — Bridge IA-Terminal</h1>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="historia-de-usuario">📋 Historia de Usuario</h2>
<blockquote>
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Como usuario</strong>, quiero enviar los comandos sugeridos por la IA directamente a la terminal, <strong>para</strong> evitar errores de escritura manual y agilizar la administración del servidor.<span class="citation-nbsp"></span><span class="inline-block align-middle"></span></p>
</blockquote>
<hr class="bg-quiet h-px border-0" node="[object Object]">
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="criterios-de-aceptacin">✅ Criterios de Aceptación</h2>
<ul class="contains-task-list">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0 task-list-item">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><input disabled="disabled" type="checkbox" checked="checked"> Botón <strong>"Ejecutar en Terminal"</strong> visible debajo de cada bloque de código generado por la IA.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0 task-list-item">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><input disabled="disabled" type="checkbox" checked="checked"> Inyección instantánea del comando en la sesión SSH activa de la pestaña <strong>Terminal</strong> (sin abrir un canal SSH nuevo).</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0 task-list-item">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><input disabled="disabled" type="checkbox" checked="checked"> Confirmación previa para comandos <strong>multi-línea</strong> antes de ejecutar.</p>
</li>
</ul>
<hr class="bg-quiet h-px border-0" node="[object Object]">
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="cambios-realizados">🔧 Cambios Realizados</h2>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id=""><code>lib/view/components/chat_bubble.dart</code></h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Añadido parámetro opcional <code>onExecuteCommand: void Function(String)?</code>.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Implementado método <code>_buildAiContent()</code> que parsea bloques de código Markdown con regex <code>```[\w]*\n([\s\S]*?)\n```</code>.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Por cada bloque detectado se renderiza un <code>TextButton.icon</code> con ícono <code>Icons.terminal</code> y label <strong>"Ejecutar en Terminal"</strong>.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El botón solo aparece en mensajes de la IA (<code>isUser == false</code>) y solo si el bloque no está vacío.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Se conserva el botón de copiar (<code>Icons.copy</code>) existente.</p>
</li>
</ul>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id=""><code>lib/view/pages/server_tabs/ChatIaTab.dart</code></h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Implementado <code>_executeInTerminal(String command)</code> que obtiene el singleton <code>Terminal</code> vía <code>getIt&lt;Terminal&gt;()</code>.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Usa <code>terminal.textInput(trimmed)</code> + <code>terminal.keyInput(TerminalKey.enter)</code> para inyectar sin abrir canal SSH.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Para comandos multi-línea (contienen <code>\n</code>) se muestra un <code>AlertDialog</code> de confirmación antes de ejecutar.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>onExecuteCommand</code> se pasa a <code>ChatBubble</code> solo para mensajes de la IA (<code>message.isUser ? null : _executeInTerminal</code>).</p>
</li>
</ul>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id=""><code>lib/injection.dart</code></h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Registrado <code>Terminal</code> como <strong>singleton</strong> con <code>getIt.registerLazySingleton&lt;Terminal&gt;(() =&gt; Terminal())</code>.</p>
</li>
</ul>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id=""><code>lib/view/pages/ServerPage.dart</code></h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>TerminalTab</code> ahora consume el singleton <code>getIt&lt;Terminal&gt;()</code> en lugar de crear una instancia local.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Eliminadas declaraciones no utilizadas <code>_showChatModal</code> y <code>_commandController</code> (limpieza de warnings).</p>
</li>
</ul>
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id=""><code>lib/view/pages/TempSessionPage.dart</code></h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>TerminalTab</code> también migrado al singleton <code>getIt&lt;Terminal&gt;()</code> para consistencia.</p>
</li>
</ul>
<hr class="bg-quiet h-px border-0" node="[object Object]">
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="decisiones-de-arquitectura">🏗️ Decisiones de Arquitectura</h2>
<div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised">
Decisión | Alternativa descartada | Razón
-- | -- | --
Escribir en Terminal (xterm) vía textInput() | Usar ServerCommandController.executeCommand() | executeCommand abre un canal SSH aislado. La inyección en xterm escribe en la sesión interactiva activa, replicando el comportamiento humano.
Singleton Terminal en get_it | Instancia local por widget | ChatIaTab y TerminalTab están en widgets distintos del árbol; el singleton garantiza que ambos operen sobre el mismo objeto xterm.
Confirmación solo para multi-línea | Confirmar siempre | Comandos  de una línea son inmediatos y seguros en contexto. El fricción extra  para comandos simples degradaría la UX sin beneficio real.

</div></div>
<hr class="bg-quiet h-px border-0" node="[object Object]">
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="cmo-probar">🧪 Cómo Probar</h2>
<ol class="marker:text-quiet list-decimal">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Conectarse a un servidor desde la app.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Ir al tab <strong>Chat IA</strong> y enviar una pregunta que genere un bloque de código (ej: <em>"¿cómo listo los procesos activos?"</em>).</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Verificar que aparece el botón <strong>"Ejecutar en Terminal"</strong> debajo del bloque.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Presionar el botón → el comando debe aparecer escrito y ejecutado en el tab <strong>Terminal</strong>.</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Probar con un script multi-línea → debe aparecer el <code>AlertDialog</code> de confirmación antes de ejecutar.</p>
</li>
</ol>
<hr class="bg-quiet h-px border-0" node="[object Object]">
<h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="referencias">📎 Referencias</h2>
<ul class="marker:text-quiet list-disc">
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Issue: <code>ES-46</code> (parent: <code>ES-44</code>)</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Branch: <code>ES-46-Bridge-IA-Terminal</code> → <code>develop</code></p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Archivos modificados: 5</p>
</li>
<li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0">
<p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Warnings resueltos: 2</p>
</li>
</ul>