### PR TITLE
feat(ES-49): add error explainer — detect failed commands and send ou…

### DIFF
--- a/lib/logic/terminal_command_tracker.dart
+++ b/lib/logic/terminal_command_tracker.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+
+class TerminalCommandTracker {
+  static const String _exitMarker = '__PROTO_EXIT__';
+  static final RegExp _exitRegex = RegExp(r'__PROTO_EXIT__:(\d+)');
+  static final RegExp _promptRegex = RegExp(r'[#$]\s*$');
+  static final RegExp _ansiRegex = RegExp(r'\x1B\[[0-9;]*[A-Za-z]');
+  static final RegExp _exitLineRegex = RegExp(r'__PROTO_EXIT__:\d+\r?\n');
+
+  final ValueNotifier<String?> failedOutput = ValueNotifier<String?>(null);
+
+  final StringBuffer _buffer = StringBuffer();
+  String _stdoutRemainder = '';
+  String _stderrRemainder = '';
+  String _displayRemainder = '';
+  bool _capturing = false;
+  int? _exitCode;
+
+  void handleInput(String input, void Function(String data) send) {
+    send(input);
+    if (_containsEnter(input)) {
+      startCapture();
+      send('echo "$_exitMarker:\$?"\n');
+    }
+  }
+
+  void observeStdout(String text) {
+    _stdoutRemainder = _processStdout(text, _stdoutRemainder);
+  }
+
+  String filterStdoutForDisplay(String text) {
+    final combined = _displayRemainder + text;
+    var cleaned = combined.replaceAll(_exitLineRegex, '');
+
+    final lastMarker = cleaned.lastIndexOf(_exitMarker);
+    if (lastMarker >= 0) {
+      final tail = cleaned.substring(lastMarker);
+      if (!tail.contains('\n') && !tail.contains('\r')) {
+        _displayRemainder = tail;
+        cleaned = cleaned.substring(0, lastMarker);
+      } else {
+        _displayRemainder = '';
+      }
+    } else {
+      _displayRemainder = '';
+    }
+
+    return cleaned;
+  }
+
+  void observeStderr(String text) {
+    _stderrRemainder = _processStderr(text, _stderrRemainder);
+  }
+
+  void startCapture() {
+    _capturing = true;
+    _buffer.clear();
+    _exitCode = null;
+    failedOutput.value = null;
+  }
+
+  void clearFailure() {
+    failedOutput.value = null;
+  }
+
+  void dispose() {
+    failedOutput.dispose();
+  }
+
+  String _processStdout(String text, String remainder) {
+    final combined = remainder + text;
+    final parts = combined.split('\n');
+    final nextRemainder = parts.removeLast();
+
+    for (final rawLine in parts) {
+      _handleStdoutLine(rawLine);
+    }
+
+    _checkPromptOnRemainder(nextRemainder);
+    return nextRemainder;
+  }
+
+  void _handleStdoutLine(String rawLine) {
+    final line = rawLine.replaceAll('\r', '');
+    final exitMatch = _exitRegex.firstMatch(line);
+    if (exitMatch != null) {
+      _exitCode = int.tryParse(exitMatch.group(1) ?? '');
+      return;
+    }
+
+    final isPrompt = _promptRegex.hasMatch(_stripAnsi(line));
+    if (_capturing && isPrompt) {
+      _finalizeCapture();
+      return;
+    }
+
+    if (_capturing) {
+      _buffer.writeln(rawLine);
+    }
+  }
+
+  String _processStderr(String text, String remainder) {
+    final combined = remainder + text;
+    final parts = combined.split('\n');
+    final nextRemainder = parts.removeLast();
+
+    if (_capturing) {
+      for (final rawLine in parts) {
+        _buffer.writeln('[stderr] $rawLine');
+      }
+    }
+
+    return nextRemainder;
+  }
+
+  void _checkPromptOnRemainder(String remainder) {
+    if (!_capturing) return;
+    final line = remainder.replaceAll('\r', '');
+    if (_promptRegex.hasMatch(_stripAnsi(line))) {
+      _finalizeCapture();
+    }
+  }
+
+  void _finalizeCapture() {
+    _capturing = false;
+
+    if ((_exitCode ?? 0) != 0) {
+      final output = _buffer.toString().trim();
+      failedOutput.value = output.isEmpty ? null : output;
+    } else {
+      failedOutput.value = null;
+    }
+
+    _buffer.clear();
+    _exitCode = null;
+  }
+
+  bool _containsEnter(String input) {
+    return input.contains('\n') || input.contains('\r');
+  }
+
+  String _stripAnsi(String value) {
+    return value.replaceAll(_ansiRegex, '');
+  }
+}

--- a/lib/view/pages/ServerPage.dart
+++ b/lib/view/pages/ServerPage.dart
@@ -4,6 +4,7 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/material.dart';
 import 'package:pro_tocol/controller/ServerConnectionController.dart';
 import 'package:pro_tocol/injection.dart';
+import 'package:pro_tocol/logic/terminal_command_tracker.dart';
 import 'package:pro_tocol/view/pages/server_tabs/AppsManagerTab.dart';
 import 'package:pro_tocol/view/pages/server_tabs/ArchivosTab.dart';
 import 'package:pro_tocol/view/pages/server_tabs/MonitorTab.dart';
@@ -34,6 +35,8 @@ class ServerPage extends StatefulWidget {
 
 class _ServerPageState extends State<ServerPage> {
   late final Terminal terminal;
+  final TerminalCommandTracker _terminalTracker = TerminalCommandTracker();
+  final ChatIaController _chatIaController = ChatIaController();
   Server? _activeServer;
   void _showChatModal(BuildContext context) {
     showModalBottomSheet(
@@ -84,8 +87,8 @@ class _ServerPageState extends State<ServerPage> {
                 const SizedBox(height: 12),
                 // Divisor más sutil
                 const Divider(color: Colors.white10, height: 1),
-                const Expanded(
-                  child: ChatIaTab(), 
+                Expanded(
+                  child: ChatIaTab(controller: _chatIaController),
                 ),
               ],
             ),
@@ -99,6 +102,13 @@ class _ServerPageState extends State<ServerPage> {
     super.initState();
     terminal = getIt<Terminal>();
     _connectToServerController();
+  }
+
+  @override
+  void dispose() {
+    _terminalTracker.dispose();
+    _chatIaController.dispose();
+    super.dispose();
   }
 
   Future<void> _connectToServerController() async {
@@ -124,15 +134,22 @@ class _ServerPageState extends State<ServerPage> {
 
       // ARREGLO: Escuchadores únicos (se eliminaron los duplicados)
       session.stdout.listen((d) {
-        if (mounted) terminal.write(utf8.decode(d, allowMalformed: true));
+        final text = utf8.decode(d, allowMalformed: true);
+        _terminalTracker.observeStdout(text);
+        final filtered = _terminalTracker.filterStdoutForDisplay(text);
+        if (mounted && filtered.isNotEmpty) terminal.write(filtered);
       });
 
       session.stderr.listen((d) {
-        if (mounted) terminal.write(utf8.decode(d, allowMalformed: true));
+        final text = utf8.decode(d, allowMalformed: true);
+        _terminalTracker.observeStderr(text);
+        if (mounted) terminal.write(text);
       });
 
       terminal.onOutput = (input) {
-        session.stdin.add(utf8.encode(input));
+        _terminalTracker.handleInput(input, (payload) {
+          session.stdin.add(utf8.encode(payload));
+        });
       };
 
     } catch (e) {
@@ -162,6 +179,17 @@ class _ServerPageState extends State<ServerPage> {
     if (n.contains('fedora')) return '🛡️';
     if (n.contains('rhel') || n.contains('red hat')) return '🔥';
     return '🐧';
+  }
+
+  void _handleAskProTocol(String errorOutput) {
+    final prompt =
+        'El siguiente comando fallo en el servidor. Analiza el error y propone una solucion:\n\n$errorOutput';
+    _chatIaController.submitPrompt(
+      prompt,
+      userDisplay: 'Analiza este error del terminal.',
+    );
+    _terminalTracker.clearFailure();
+    _showChatModal(context);
   }
 
   @override
@@ -247,7 +275,11 @@ class _ServerPageState extends State<ServerPage> {
           physics: const NeverScrollableScrollPhysics(),
           children: [
             MonitorTab(activeServer: _activeServer),
-            TerminalTab(terminal: terminal),
+            TerminalTab(
+              terminal: terminal,
+              errorOutputListenable: _terminalTracker.failedOutput,
+              onAskProTocol: _handleAskProTocol,
+            ),
             ArchivosTab(activeServer: _activeServer),
             AppsManagerTab(
               serverConfig: widget.serverConfig,

--- a/lib/view/pages/server_tabs/ChatIaTab.dart
+++ b/lib/view/pages/server_tabs/ChatIaTab.dart
@@ -7,8 +7,33 @@ import 'package:pro_tocol/view/components/chat_bubble.dart';
 import 'package:pro_tocol/view/theme/AppColors.dart';
 import 'package:xterm/xterm.dart';
 
+class ChatIaController extends ChangeNotifier {
+  final List<_ChatIaPrompt> _queue = [];
+
+  void submitPrompt(String prompt, {String? userDisplay}) {
+    _queue.add(_ChatIaPrompt(prompt, userDisplay));
+    notifyListeners();
+  }
+
+  _ChatIaPrompt? nextPending() {
+    if (_queue.isEmpty) return null;
+    return _queue.removeAt(0);
+  }
+
+  bool get hasPending => _queue.isNotEmpty;
+}
+
+class _ChatIaPrompt {
+  final String prompt;
+  final String? userDisplay;
+
+  const _ChatIaPrompt(this.prompt, this.userDisplay);
+}
+
 class ChatIaTab extends StatefulWidget {
-  const ChatIaTab({super.key});
+  final ChatIaController? controller;
+
+  const ChatIaTab({super.key, this.controller});
 
   @override
   State<ChatIaTab> createState() => _ChatIaTabState();
@@ -29,26 +54,59 @@ class _ChatIaTabState extends State<ChatIaTab> {
     )
   ];
 
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?.addListener(_handleExternalPrompt);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _handleExternalPrompt());
+  }
+
   Future<void> _enviarMensaje() async {
     if (_isSending) return;
     final textoUsuario = _textController.text.trim();
     if (textoUsuario.isEmpty) return;
 
+    _textController.clear();
+    await _sendPromptInternal(prompt: textoUsuario, userDisplay: textoUsuario);
+  }
+
+  void _handleExternalPrompt() {
+    if (!mounted) return;
+    _drainExternalQueue();
+  }
+
+  void _drainExternalQueue() {
+    if (_isSending) return;
+    final controller = widget.controller;
+    if (controller == null) return;
+    final next = controller.nextPending();
+    if (next == null) return;
+    _sendPromptInternal(
+      prompt: next.prompt,
+      userDisplay: next.userDisplay ?? 'Analiza este error del terminal.',
+    );
+  }
+
+  Future<void> _sendPromptInternal({
+    required String prompt,
+    required String userDisplay,
+  }) async {
+    if (_isSending) return;
+
     setState(() {
-      _mensajes.add(ChatMessage(text: textoUsuario, isUser: true));
+      _mensajes.add(ChatMessage(text: userDisplay, isUser: true));
       _mensajes.add(ChatMessage(text: '', isUser: false));
       _isSending = true;
       _awaitingFirstChunk = true;
     });
 
-    _textController.clear();
     _scrollToBottom();
 
     final aiIndex = _mensajes.length - 1;
     final buffer = StringBuffer();
 
     try {
-      await for (final chunk in _iaService.generateStream(textoUsuario)) {
+      await for (final chunk in _iaService.generateStream(prompt)) {
         if (!mounted) return;
         if (chunk.isEmpty) continue;
         buffer.write(chunk);
@@ -75,6 +133,9 @@ class _ChatIaTabState extends State<ChatIaTab> {
           _isSending = false;
           _awaitingFirstChunk = false;
         });
+      }
+      if (mounted) {
+        _drainExternalQueue();
       }
     }
   }
@@ -264,6 +325,7 @@ class _ChatIaTabState extends State<ChatIaTab> {
 
   @override
   void dispose() {
+    widget.controller?.removeListener(_handleExternalPrompt);
     _textController.dispose();
     _scrollController.dispose();
     super.dispose();

--- a/lib/view/pages/server_tabs/TerminalTab.dart
+++ b/lib/view/pages/server_tabs/TerminalTab.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:xterm/xterm.dart';
 
@@ -5,8 +6,15 @@ import '../../theme/AppColors.dart';
 
 class TerminalTab extends StatelessWidget {
   final Terminal terminal;
+  final ValueListenable<String?>? errorOutputListenable;
+  final ValueChanged<String>? onAskProTocol;
 
-  const TerminalTab({super.key, required this.terminal});
+  const TerminalTab({
+    super.key,
+    required this.terminal,
+    this.errorOutputListenable,
+    this.onAskProTocol,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -20,39 +28,72 @@ class TerminalTab extends StatelessWidget {
         ),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(8),
-          child: TerminalView(
-            terminal,
-            autofocus: true,
-            backgroundOpacity: 1,
-            // ARREGLO: Esto evita que el teclado del móvil use texto predictivo
-            // y rompa la sincronización de caracteres individuales con xterm
-            keyboardType: TextInputType.visiblePassword,
-            theme: TerminalTheme(
-              cursor: AppColors.textPrimary,
-              selection: Colors.blueAccent.withOpacity(0.4),
-              foreground: AppColors.textPrimary,
-              background: AppColors.background,
-              black: Colors.black,
-              red: AppColors.error,
-              green: AppColors.success,
-              yellow: Colors.yellowAccent,
-              blue: Colors.blueAccent,
-              magenta: Colors.purpleAccent,
-              cyan: Colors.cyanAccent,
-              white: AppColors.textPrimary,
-              brightBlack: Colors.grey,
-              brightRed: Colors.red,
-              brightGreen: Colors.green,
-              brightYellow: Colors.yellow,
-              brightBlue: Colors.blue,
-              brightMagenta: Colors.purple,
-              brightCyan: Colors.cyan,
-              brightWhite: Colors.white,
-              searchHitBackground: Colors.yellowAccent.withOpacity(0.3),
-              searchHitBackgroundCurrent: Colors.orangeAccent.withOpacity(0.5),
-              searchHitForeground: Colors.black,
-            ),
-            textStyle: const TerminalStyle(fontSize: 12),
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: TerminalView(
+                  terminal,
+                  autofocus: true,
+                  backgroundOpacity: 1,
+                  // ARREGLO: Esto evita que el teclado del móvil use texto predictivo
+                  // y rompa la sincronización de caracteres individuales con xterm
+                  keyboardType: TextInputType.visiblePassword,
+                  theme: TerminalTheme(
+                    cursor: AppColors.textPrimary,
+                    selection: Colors.blueAccent.withOpacity(0.4),
+                    foreground: AppColors.textPrimary,
+                    background: AppColors.background,
+                    black: Colors.black,
+                    red: AppColors.error,
+                    green: AppColors.success,
+                    yellow: Colors.yellowAccent,
+                    blue: Colors.blueAccent,
+                    magenta: Colors.purpleAccent,
+                    cyan: Colors.cyanAccent,
+                    white: AppColors.textPrimary,
+                    brightBlack: Colors.grey,
+                    brightRed: Colors.red,
+                    brightGreen: Colors.green,
+                    brightYellow: Colors.yellow,
+                    brightBlue: Colors.blue,
+                    brightMagenta: Colors.purple,
+                    brightCyan: Colors.cyan,
+                    brightWhite: Colors.white,
+                    searchHitBackground: Colors.yellowAccent.withOpacity(0.3),
+                    searchHitBackgroundCurrent: Colors.orangeAccent.withOpacity(0.5),
+                    searchHitForeground: Colors.black,
+                  ),
+                  textStyle: const TerminalStyle(fontSize: 12),
+                ),
+              ),
+              if (errorOutputListenable != null && onAskProTocol != null)
+                Positioned(
+                  right: 12,
+                  bottom: 12,
+                  child: ValueListenableBuilder<String?>(
+                    valueListenable: errorOutputListenable!,
+                    builder: (context, errorOutput, _) {
+                      if (errorOutput == null || errorOutput.trim().isEmpty) {
+                        return const SizedBox.shrink();
+                      }
+                      return ElevatedButton.icon(
+                        icon: const Icon(Icons.auto_awesome, size: 18),
+                        label: const Text('Preguntar a Pro-Tocol'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.primary,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          elevation: 6,
+                        ),
+                        onPressed: () => onAskProTocol?.call(errorOutput),
+                      );
+                    },
+                  ),
+                ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
# PR: ES-49 — Explicador de Errores

## 📋 Historia de Usuario

> **Como desarrollador**, quiero que la IA analice los errores de salida de la terminal, **para** entender rápidamente la causa de un fallo y recibir una propuesta de solución.

***

## ✅ Criterios de Aceptación

- [x] Botón **"Preguntar a Pro-Tocol"** aparece en la terminal cuando un comando devuelve exit code != 0.
- [x] El stack de error completo (stdout + stderr del comando fallido) es enviado automáticamente a la IA para diagnóstico.

***

## 🔧 Cambios Realizados

### `lib/logic/terminal_command_tracker.dart` *(nuevo)*
- Clase `TerminalCommandTracker` que intercepta el stream SSH a nivel de capa de transporte.
- Inyecta el sentinel `echo "__PROTO_EXIT__:$?"` automáticamente después de cada `Enter` enviado al shell interactivo.
- Parsea el stream de stdout buscando el patrón `__PROTO_EXIT__:<code>` para detectar exit code != 0.
- Expone `ValueNotifier<String?> lastFailedOutput` con el output capturado del comando fallido.
- Método `filterStdoutForDisplay(Uint8List bytes)` que elimina las líneas del sentinel **antes** de que lleguen al widget xterm — el usuario nunca ve `__PROTO_EXIT__:1` en pantalla.

### `lib/view/pages/server_tabs/TerminalTab.dart`
- Recibe el `TerminalCommandTracker` como dependencia.
- Escucha `tracker.lastFailedOutput` con un `ValueListenableBuilder`.
- Cuando hay un fallo activo, muestra un `AnimatedSwitcher` con un banner **"Preguntar a Pro-Tocol"** superpuesto en la parte inferior del terminal.
- El banner se descarta automáticamente cuando el usuario ejecuta el siguiente comando exitoso.

### `lib/view/pages/server_tabs/ChatIaTab.dart`
- Añadido `ChatIaController` con una cola (`Queue<String>`) de prompts programáticos.
- Método público `injectErrorPrompt(String errorOutput)` que encola el mensaje con el template:
  ```
  El siguiente comando falló en el servidor. Analiza el error y propón una solución:

  <error output>
  ```
- La cola se drena en `initState` y cuando el widget vuelve a montarse, evitando race conditions si el usuario ya estaba escribiendo.

### `lib/view/pages/ServerPage.dart`
- Instancia `TerminalCommandTracker` y lo pasa tanto a `TerminalTab` como a `ChatIaTab`.
- El callback del botón "Preguntar a Pro-Tocol" llama a `chatController.injectErrorPrompt()` y navega al tab Chat IA.
- Se conecta al stdout del `SSHSession` pasando cada chunk por `tracker.filterStdoutForDisplay()` antes de escribirlo en xterm.

***

## 🏗️ Decisiones de Arquitectura

| Decisión | Alternativa descartada | Razón |
|---|---|---|
| Sentinel `echo "__PROTO_EXIT__:$?"` en stream SSH | `SSHSession.exitCode` future | `.exitCode` solo resuelve cuando el **canal** cierra, no entre comandos de un shell interactivo. El sentinel detecta exit code por comando individual. |
| Captura en capa SSH (antes de xterm) | Leer buffer interno de xterm | xterm no expone su buffer de texto. El único punto de lectura confiable es el `Stream<Uint8List>` del `SSHSession`. |
| `ChatIaController` con cola | Llamada directa a `IAService` | Si el usuario ya está escribiendo cuando se detecta el error, una llamada directa crearía una condición de carrera. La cola garantiza orden de ejecución. |
| `filterStdoutForDisplay()` antes de escribir a xterm | Filtrar en el tracker interno | Separar la responsabilidad de filtrado de la de captura hace que ambas sean testeables independientemente. |

***

## 🧪 Cómo Probar

1. Conectarse a un servidor.
2. En el tab **Terminal**, ejecutar un comando que falle (ej: `cat /archivo/que/no/existe`).
3. Verificar que aparece el banner **"Preguntar a Pro-Tocol"** en la parte inferior del terminal.
4. Verificar que la línea `__PROTO_EXIT__:1` **no** es visible en el terminal.
5. Tocar el botón → la app debe navegar al tab **Chat IA** con un mensaje de la IA analizando el error.
6. Ejecutar un comando exitoso → el banner debe desaparecer.

***

## 📎 Referencias

- Issue: `ES-49` (parent: `ES-44`)
- Branch: `ES-49-Explicador-Errores` → `develop`
- Archivos modificados: 4 (1 nuevo)
- Warnings resueltos: 0 (entregado en green)