### PR TITLE
feat(ES-70): CRUD Historial de Chat — fix Isar, swipe-to-delete, edición de prompts

### DIFF
--- a/lib/model/entities/chat_message_entity.dart
+++ b/lib/model/entities/chat_message_entity.dart
@@ -6,12 +6,12 @@ part 'chat_message_entity.g.dart';
 class ChatMessageEntity {
   Id id = Isar.autoIncrement;
 
-  
-  final String serverIp; // Para filtrar mensajes por servidor
-  final String profileId; // Para filtrar mensajes por perfil/usuario
-  final String role;     // 'user' o 'assistant'
-  final String content;
-  final DateTime timestamp;
+  late String serverIp; // Para filtrar mensajes por servidor
+  late String profileId; // Para filtrar mensajes por perfil/usuario
+  late String role; // 'user' o 'assistant'
+  late String content;
+  String? editedContent;
+  late DateTime timestamp;
 
   ChatMessageEntity({
     required this.serverIp,

--- a/lib/model/entities/chat_message_entity.g.dart
+++ b/lib/model/entities/chat_message_entity.g.dart
@@ -22,23 +22,28 @@ const ChatMessageEntitySchema = CollectionSchema(
       name: r'content',
       type: IsarType.string,
     ),
-    r'profileId': PropertySchema(
+    r'editedContent': PropertySchema(
       id: 1,
+      name: r'editedContent',
+      type: IsarType.string,
+    ),
+    r'profileId': PropertySchema(
+      id: 2,
       name: r'profileId',
       type: IsarType.string,
     ),
     r'role': PropertySchema(
-      id: 2,
+      id: 3,
       name: r'role',
       type: IsarType.string,
     ),
     r'serverIp': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'serverIp',
       type: IsarType.string,
     ),
     r'timestamp': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'timestamp',
       type: IsarType.dateTime,
     )
@@ -64,6 +69,12 @@ int _chatMessageEntityEstimateSize(
 ) {
   var bytesCount = offsets.last;
   bytesCount += 3 + object.content.length * 3;
+  {
+    final value = object.editedContent;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
   bytesCount += 3 + object.profileId.length * 3;
   bytesCount += 3 + object.role.length * 3;
   bytesCount += 3 + object.serverIp.length * 3;
@@ -77,10 +88,11 @@ void _chatMessageEntitySerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeString(offsets[0], object.content);
-  writer.writeString(offsets[1], object.profileId);
-  writer.writeString(offsets[2], object.role);
-  writer.writeString(offsets[3], object.serverIp);
-  writer.writeDateTime(offsets[4], object.timestamp);
+  writer.writeString(offsets[1], object.editedContent);
+  writer.writeString(offsets[2], object.profileId);
+  writer.writeString(offsets[3], object.role);
+  writer.writeString(offsets[4], object.serverIp);
+  writer.writeDateTime(offsets[5], object.timestamp);
 }
 
 ChatMessageEntity _chatMessageEntityDeserialize(
@@ -91,11 +103,12 @@ ChatMessageEntity _chatMessageEntityDeserialize(
 ) {
   final object = ChatMessageEntity(
     content: reader.readString(offsets[0]),
-    profileId: reader.readString(offsets[1]),
-    role: reader.readString(offsets[2]),
-    serverIp: reader.readString(offsets[3]),
-    timestamp: reader.readDateTime(offsets[4]),
+    profileId: reader.readString(offsets[2]),
+    role: reader.readString(offsets[3]),
+    serverIp: reader.readString(offsets[4]),
+    timestamp: reader.readDateTime(offsets[5]),
   );
+  object.editedContent = reader.readStringOrNull(offsets[1]);
   object.id = id;
   return object;
 }
@@ -110,12 +123,14 @@ P _chatMessageEntityDeserializeProp<P>(
     case 0:
       return (reader.readString(offset)) as P;
     case 1:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 2:
       return (reader.readString(offset)) as P;
     case 3:
       return (reader.readString(offset)) as P;
     case 4:
+      return (reader.readString(offset)) as P;
+    case 5:
       return (reader.readDateTime(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -349,6 +364,160 @@ extension ChatMessageEntityQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'content',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'editedContent',
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'editedContent',
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'editedContent',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'editedContent',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'editedContent',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'editedContent',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterFilterCondition>
+      editedContentIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'editedContent',
         value: '',
       ));
     });
@@ -898,6 +1067,20 @@ extension ChatMessageEntityQuerySortBy
   }
 
   QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterSortBy>
+      sortByEditedContent() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'editedContent', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterSortBy>
+      sortByEditedContentDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'editedContent', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterSortBy>
       sortByProfileId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'profileId', Sort.asc);
@@ -967,6 +1150,20 @@ extension ChatMessageEntityQuerySortThenBy
       thenByContentDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'content', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterSortBy>
+      thenByEditedContent() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'editedContent', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QAfterSortBy>
+      thenByEditedContentDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'editedContent', Sort.desc);
     });
   }
 
@@ -1050,6 +1247,14 @@ extension ChatMessageEntityQueryWhereDistinct
   }
 
   QueryBuilder<ChatMessageEntity, ChatMessageEntity, QDistinct>
+      distinctByEditedContent({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'editedContent',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, ChatMessageEntity, QDistinct>
       distinctByProfileId({bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'profileId', caseSensitive: caseSensitive);
@@ -1089,6 +1294,13 @@ extension ChatMessageEntityQueryProperty
   QueryBuilder<ChatMessageEntity, String, QQueryOperations> contentProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'content');
+    });
+  }
+
+  QueryBuilder<ChatMessageEntity, String?, QQueryOperations>
+      editedContentProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'editedContent');
     });
   }
 

--- a/lib/model/repositories/ChatHistoryRepository.dart
+++ b/lib/model/repositories/ChatHistoryRepository.dart
@@ -23,4 +23,33 @@ class ChatHistoryRepository {
         .sortByTimestamp()
         .findAll();
   }
+
+  Future<void> deleteMessage(int id) async {
+    await isar.writeTxn(() async {
+      await isar.chatMessageEntitys.delete(id);
+    });
+  }
+
+  Future<void> deleteAllByServerAndProfile(String ip, String profileId) async {
+    await isar.writeTxn(() async {
+      final messages = await isar.chatMessageEntitys
+          .filter()
+          .serverIpEqualTo(ip)
+          .and()
+          .profileIdEqualTo(profileId)
+          .findAll();
+      if (messages.isEmpty) return;
+      final ids = messages.map((e) => e.id).toList();
+      await isar.chatMessageEntitys.deleteAll(ids);
+    });
+  }
+
+  Future<void> updateMessageContent(int id, String newContent) async {
+    await isar.writeTxn(() async {
+      final message = await isar.chatMessageEntitys.get(id);
+      if (message == null) return;
+      message.editedContent = newContent;
+      await isar.chatMessageEntitys.put(message);
+    });
+  }
 }

--- a/lib/view/pages/server_tabs/ChatIaTab.dart
+++ b/lib/view/pages/server_tabs/ChatIaTab.dart
@@ -87,8 +87,9 @@ class _ChatIaTabState extends State<ChatIaTab> {
         ];
       } else {
         _mensajes = mensajesDb
-            .map((e) => ChatMessage(text: e.content, isUser: e.role == 'user'))
-            .toList();
+          .map((e) => ChatMessage(
+            text: e.editedContent ?? e.content, isUser: e.role == 'user'))
+          .toList();
       }
     });
     _scrollToBottom();
@@ -274,6 +275,68 @@ class _ChatIaTabState extends State<ChatIaTab> {
     _scrollToBottom();
   }
 
+  Future<ChatMessageEntity?> _findUserMessageEntityByText(String text) async {
+    final mensajesDb = await _historyRepo.getMessagesByServerAndProfile(
+        widget.serverIp, widget.profileId);
+    for (final entity in mensajesDb) {
+      final display = entity.editedContent ?? entity.content;
+      if (entity.role == 'user' && display == text) {
+        return entity;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _deleteAllChat() async {
+    await _historyRepo.deleteAllByServerAndProfile(
+        widget.serverIp, widget.profileId);
+    await _cargarHistorial();
+  }
+
+  Future<void> _editUserMessage(int index, ChatMessage message) async {
+    final controller = TextEditingController(text: message.text);
+    final newText = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        title: const Text('Editar mensaje',
+            style: TextStyle(color: AppColors.textPrimary)),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          maxLines: null,
+          style: const TextStyle(color: AppColors.textPrimary),
+          decoration: const InputDecoration(
+            hintText: 'Editar mensaje...',
+            hintStyle: TextStyle(color: AppColors.textMuted),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('Guardar'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (newText == null || newText.isEmpty) return;
+
+    final entity = await _findUserMessageEntityByText(message.text);
+    if (entity != null) {
+      await _historyRepo.updateMessageContent(entity.id, newText);
+    }
+    if (!mounted) return;
+    setState(() {
+      _mensajes[index] = ChatMessage(text: newText, isUser: true);
+    });
+  }
+
   // ================= CHAT NORMAL (original) =================
 
   Future<void> _handleNormalChat(String prompt) async {
@@ -440,10 +503,40 @@ class _ChatIaTabState extends State<ChatIaTab> {
               if (!message.isUser && message.text.isEmpty && _awaitingFirstChunk) {
                 return const _TypingIndicatorBubble();
               }
+              if (message.isUser) {
+                return Dismissible(
+                  key: ValueKey(
+                      _mensajes[index].hashCode.toString() + index.toString()),
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    color: Colors.redAccent,
+                    child: const Icon(Icons.delete_outline, color: Colors.white),
+                  ),
+                  onDismissed: (_) async {
+                    final entity =
+                        await _findUserMessageEntityByText(message.text);
+                    if (entity != null) {
+                      await _historyRepo.deleteMessage(entity.id);
+                    }
+                    if (!mounted) return;
+                    setState(() {
+                      _mensajes.removeAt(index);
+                    });
+                  },
+                  child: GestureDetector(
+                    onLongPress: () => _editUserMessage(index, message),
+                    child: ChatBubble(
+                      message: message,
+                      onExecuteCommand: null,
+                    ),
+                  ),
+                );
+              }
               return ChatBubble(
                 message: message,
-                onExecuteCommand:
-                    message.isUser ? null : _executeInTerminal,
+                onExecuteCommand: _executeInTerminal,
               );
             },
           ),
@@ -476,6 +569,12 @@ class _ChatIaTabState extends State<ChatIaTab> {
                       activeColor: AppColors.primary,
                     ),
                   ],
+                ),
+                IconButton(
+                  onPressed: _isSending ? null : _deleteAllChat,
+                  icon: const Icon(Icons.delete_outline),
+                  color: AppColors.textMuted,
+                  tooltip: 'Borrar historial',
                 ),
                 const SizedBox(width: 8),
                 Expanded(


### PR DESCRIPTION
## Historia de Usuario ES-70 — CRUD: Historial de Chat

### Problema resuelto
- Mala gestión de datos en Isar: campos `final` en `ChatMessageEntity` impedían updates correctos.

### Cambios
- **`chat_message_entity.dart`**: campos mutables (sin `final`), nuevo campo opcional `editedContent` para ediciones del usuario
- **`ChatHistoryRepository.dart`**: nuevas operaciones CRUD:
  - `deleteMessage(int id)` — borrar mensaje por ID
  - `deleteAllByServerAndProfile(String ip, String profileId)` — limpiar historial completo
  - `updateMessageContent(int id, String newContent)` — actualizar contenido de un mensaje
- **`ChatIaTab.dart`**:
  - Historial muestra `editedContent` cuando existe
  - Swipe derecha→izquierda en mensajes del usuario para eliminar (Dismissible)
  - Long press en mensaje del usuario abre diálogo de edición
  - Ícono de basura en UI para borrar todo el historial
- **`chat_message_entity.g.dart`**: regenerado con `build_runner`

### Funcionalidades sin modificar
- Modo Script y generación de scripts
- Ejecución SSH/SFTP en servidor
- Cola de prompts externos (ChatIaController)
- Carga y guardado normal del historial